### PR TITLE
Use new version of lullabot/amp

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "php": ">=5.5.9|^7.0",
-        "lullabot/amp": "1.0.*",
+        "lullabot/amp": "1.1.*",
         "symfony/framework-bundle": "^3.0|^4.1",
         "symfony/twig-bundle": "^3.0|^4.1"
     },


### PR DESCRIPTION
Latest release contains fix for discovering server url used for amp-img tags generation. 